### PR TITLE
apply default options args(header, baseURL)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,36 @@ export type NextFetchDefaultOptions = {
  */
 export type FetchArgs = [string | URL, RequestInit | undefined];
 
+interface RequestInit {
+  /** next fetch does not have a method attribute because it has http request method. */
+
+  /** A BodyInit object or null to set request's body. */
+  data?: BodyInit | null;
+  /** A string indicating how the request will interact with the browser's cache to set request's cache. */
+  cache?: RequestCache;
+  /** A string indicating whether credentials will be sent with the request always, never, or only when sent to a same-origin URL. Sets request's credentials. */
+  credentials?: RequestCredentials;
+  /** A Headers object, an object literal, or an array of two-item arrays to set request's headers. */
+  headers?: HeadersInit;
+  /** A cryptographic hash of the resource to be fetched by request. Sets request's integrity. */
+  integrity?: string;
+  /** A boolean to set request's keepalive. */
+  keepalive?: boolean;
+  /** A string to indicate whether the request will use CORS, or will be restricted to same-origin URLs. Sets request's mode. */
+  mode?: RequestMode;
+  priority?: RequestPriority;
+  /** A string indicating whether request follows redirects, results in an error upon encountering a redirect, or returns the redirect (in an opaque fashion). Sets request's redirect. */
+  redirect?: RequestRedirect;
+  /** A string whose value is a same-origin URL, "about:client", or the empty string, to set request's referrer. */
+  referrer?: string;
+  /** A referrer policy to set request's referrerPolicy. */
+  referrerPolicy?: ReferrerPolicy;
+  /** An AbortSignal to set request's signal. */
+  signal?: AbortSignal | null;
+  /** Can only be null. Used to disassociate request from any Window. */
+  window?: null;
+}
+
 const applyDefaultOptionsArgs = (
   [url, requestInit]: FetchArgs,
   defaultOptions?: NextFetchDefaultOptions,
@@ -79,13 +109,13 @@ export const nextFetch = {
     const instance = {
       async get(
         url: string | URL,
-        args: Parameters<typeof fetch>,
+        args?: RequestInit,
       ): Promise<Response | any> {
         // 개발 진행 중이므로 any타입을 임의로 추가
 
         // default options를 적용한 args 생성
         const requestArgs = applyDefaultOptionsArgs(
-          [url, args[1]],
+          [url, args],
           defaultOptions,
         );
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,12 +24,6 @@ export type NextFetchDefaultOptions = {
    */
   responseJson?: boolean;
   /**
-   * Request Json of fetch. If the requestJson attribute is true, request data type is json
-   *
-   * @public
-   */
-  requestJson?: boolean;
-  /**
    * Response Interceptor of fetch. It will be called after response
    *
    * @public

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,11 +43,52 @@ export type NextFetchDefaultOptions = {
   requestInterceptor?: (responseArg: ResponseInit) => Promise<ResponseInit>;
 };
 
+/**
+ * Arguments of fetch function.
+ *
+ * @throws {Error} if a first argument of fetch is `Request` object. only string and URL are supported.
+ *
+ * @public
+ */
+export type FetchArgs = [string | URL, RequestInit | undefined];
+
+const applyDefaultOptionsArgs = (
+  [url, requestInit]: FetchArgs,
+  defaultOptions?: NextFetchDefaultOptions,
+): FetchArgs => {
+  const returnUrl: FetchArgs[0] = defaultOptions?.baseUrl
+    ? new URL(url, defaultOptions.baseUrl)
+    : url;
+
+  const headers = new Headers({
+    ...defaultOptions?.headers,
+    ...requestInit?.headers,
+  });
+
+  return [
+    returnUrl,
+    {
+      ...requestInit,
+      headers,
+    },
+  ];
+};
+
 export const nextFetch = {
-  create: (defaultOptions: NextFetchDefaultOptions) => {
+  create: (defaultOptions?: NextFetchDefaultOptions) => {
     const instance = {
-      get(): any {
-        // default options를 가지고 options 만들기
+      async get(
+        url: string | URL,
+        ...args: Parameters<typeof fetch>
+      ): Promise<Response | any> {
+        // 개발 진행 중이므로 any타입을 임의로 추가
+
+        // default options를 적용한 args 생성
+        const defaultOptionAppliedArgs = applyDefaultOptionsArgs(
+          [url, args[1]],
+          defaultOptions,
+        );
+
         // request interceptor 실행
         // 요청
         // response interceptor 실행

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,6 +74,12 @@ interface RequestInit {
   signal?: AbortSignal | null;
   /** Can only be null. Used to disassociate request from any Window. */
   window?: null;
+  /** Response Interceptor of fetch. It will be called after response */
+  responseInterceptor?: (requestArg: RequestInit) => Promise<RequestInit>;
+  /** Request Interceptor of fetch. It will be called before request */
+  requestInterceptor?: (responseArg: ResponseInit) => Promise<ResponseInit>;
+  /** Throw Error of fetch. If the throwError attribute is true, throw an error when the status is 300 or more */
+  throwError?: boolean;
 }
 
 const applyDefaultOptionsArgs = (

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,7 @@ interface RequestInit {
   /** next fetch does not have a method attribute because it has http request method. */
 
   /** A BodyInit object or null to set request's body. */
-  data?: BodyInit | null;
+  data?: BodyInit | Record<string, any>;
   /** A string indicating how the request will interact with the browser's cache to set request's cache. */
   cache?: RequestCache;
   /** A string indicating whether credentials will be sent with the request always, never, or only when sent to a same-origin URL. Sets request's credentials. */
@@ -75,11 +75,13 @@ interface RequestInit {
   /** Can only be null. Used to disassociate request from any Window. */
   window?: null;
   /** Response Interceptor of fetch. It will be called after response */
-  responseInterceptor?: (requestArg: RequestInit) => Promise<RequestInit>;
+  responseInterceptor?: (response: Response) => Promise<Response>;
   /** Request Interceptor of fetch. It will be called before request */
-  requestInterceptor?: (responseArg: ResponseInit) => Promise<ResponseInit>;
+  requestInterceptor?: (requestArg: RequestInit) => Promise<RequestInit>;
   /** Throw Error of fetch. If the throwError attribute is true, throw an error when the status is 300 or more */
   throwError?: boolean;
+  /** data's type */
+  responseType?: ResponseType;
 }
 
 const applyDefaultOptionsArgs = (
@@ -120,6 +122,7 @@ export const nextFetch = {
         );
 
         // request interceptor 실행
+
         // 요청
         // response interceptor 실행
         // 요청 값 반환

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,20 +56,20 @@ const applyDefaultOptionsArgs = (
   [url, requestInit]: FetchArgs,
   defaultOptions?: NextFetchDefaultOptions,
 ): FetchArgs => {
-  const returnUrl: FetchArgs[0] = defaultOptions?.baseUrl
+  const requestUrl: FetchArgs[0] = defaultOptions?.baseUrl
     ? new URL(url, defaultOptions.baseUrl)
     : url;
 
-  const headers = new Headers({
+  const requestHeaders = new Headers({
     ...defaultOptions?.headers,
     ...requestInit?.headers,
   });
 
   return [
-    returnUrl,
+    requestUrl,
     {
       ...requestInit,
-      headers,
+      headers: requestHeaders,
     },
   ];
 };
@@ -84,7 +84,7 @@ export const nextFetch = {
         // 개발 진행 중이므로 any타입을 임의로 추가
 
         // default options를 적용한 args 생성
-        const defaultOptionAppliedArgs = applyDefaultOptionsArgs(
+        const requestArgs = applyDefaultOptionsArgs(
           [url, args[1]],
           defaultOptions,
         );

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,7 +79,7 @@ export const nextFetch = {
     const instance = {
       async get(
         url: string | URL,
-        ...args: Parameters<typeof fetch>
+        args: Parameters<typeof fetch>,
       ): Promise<Response | any> {
         // 개발 진행 중이므로 any타입을 임의로 추가
 


### PR DESCRIPTION
## **📌** 작업 내용

> 구현 내용 및 작업 했던 내역

- 정의한 기본 옵션 중 baseURL, headers을 args에 추가하는 `applyDefaultOptionsArgs`함수를 개발하였습니다.

### 현재 커버한 DefaultOptions

- header
- baseURL


### <s> 추가로 진행해야하는  DefaultOptions</s> <- 작업 내역 분리로 인한 삭제

<s>
- Interceptor
- error 
- json 
</s>

### customRequestInit 생성

기존 requestInit을 base로

- body → data로 변경
- method 삭제
- responseInterceptor 추가
- requestInterceptor 추가
- throwError 추가


## 🤔 고민 했던 부분

- fetch의  첫번째 인자는 `Request | string` 타입을 받지만 axios문법에 따라서 `string | URL`형식으로 타입을 지정했습니다.