### PR TITLE
Process response

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -16,6 +16,7 @@ module.exports = {
         'test',
         'build',
         'setting',
+        'example',
       ],
     ],
   },

--- a/examples/type.ts
+++ b/examples/type.ts
@@ -1,0 +1,8 @@
+import { nextFetch } from '../src';
+
+// 사용자가 설정한 타입이 데이터 타입으로 잘 오는지 확인
+const fetch = nextFetch.create({ responseType: 'json' });
+const a = await fetch.get<{
+  zpp: number;
+}>('http://localhost:3001/json');
+console.log(a.data);

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,0 +1,15 @@
+class NextFetchError extends Error {
+  constructor(
+    readonly statusCode: number,
+    readonly response: Response,
+  ) {
+    super();
+    this.statusCode = statusCode;
+    this.response = response;
+  }
+}
+
+const httpErrorHandling = (response: Response) => {
+  if (response.status >= 300)
+    throw new NextFetchError(response.status, response);
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,31 @@
+// // Prepare the response
+// const responseHeaders = AxiosHeaders.from(
+//   'getAllResponseHeaders' in request && request.getAllResponseHeaders()
+// );
+// const responseData = !responseType || responseType === 'text' || responseType === 'json' ?
+//   request.responseText : request.response;
+// const response = {
+//   data: responseData,
+//   status: request.status,
+//   statusText: request.statusText,
+//   headers: responseHeaders,
+//   config, // AxiosRequestConfig에 header만 추가된 타입
+//   request // axios 공식 문서를 보면 응답을 생성한 요청이라는데 어디에 사용되는지 모르겠음
+// };
+
+export type NextFetchResponse<T = any> = {
+  data: T;
+  status: number;
+  statusText: string;
+  headers: Headers;
+};
+
+interface NextFetchRequestInit<T = any> extends RequestInit {
+  data?: T;
+  throwError?: boolean;
+  responseJson?: boolean;
+  requestJson?: boolean;
+}
 export type NextFetchDefaultOptions = {
   /**
    * Base URL of fetch. It will be used when the first argument of fetch is relative URL.
@@ -22,35 +50,73 @@ export type NextFetchDefaultOptions = {
    *
    * @public
    */
-  responseJson?: boolean;
-  /**
-   * Request Json of fetch. If the requestJson attribute is true, request data type is json
-   *
-   * @public
-   */
   requestJson?: boolean;
   /**
    * Response Interceptor of fetch. It will be called after response
    *
    * @public
    */
-  responseInterceptor?: (requestArg: RequestInit) => Promise<RequestInit>;
+  responseType?:
+    | 'arraybuffer'
+    | 'blob'
+    | 'json'
+    | 'text'
+    | 'stream'
+    | 'formdata';
+  responseInterceptor?: (response: Response) => Promise<Response>;
   /**
    * Request Interceptor of fetch. It will be called before request
    *
    * @public
    */
-  requestInterceptor?: (responseArg: ResponseInit) => Promise<ResponseInit>;
+  requestInterceptor?: (requestArg: RequestInit) => Promise<RequestInit>;
+};
+
+// createResponse가 할 일
+const getContentType = (responseHeaders: Headers) => {
+  const header = new Headers(responseHeaders);
+  return header.get('Content-Type') as string; // content-type이 없는 경우를 고려 X
+};
+const processResponse = async (
+  fetchResponse: Response,
+  responseType: NextFetchDefaultOptions['responseType'],
+) => {
+  let type = responseType
+    ? responseType
+    : getContentType(fetchResponse.headers);
+
+  let data: ArrayBuffer | JSON;
+
+  // response type을 먼저 확인한다
+  // response type이 없으면 content-type을 확인한다
+  // type을 가지고 data를 가공한 후 반환
 };
 
 export const nextFetch = {
-  create: (defaultOptions: NextFetchDefaultOptions) => {
+  create: (defaultOptions?: NextFetchDefaultOptions) => {
     const instance = {
-      get(): any {
+      async get<T = any>(
+        url: string | URL,
+        ...args: Parameters<typeof fetch>
+      ): Promise<any> {
         // default options를 가지고 options 만들기
-        // request interceptor 실행
-        // 요청
-        // response interceptor 실행
+        let requestArgs: any;
+        if (defaultOptions?.requestInterceptor) {
+          requestArgs = await defaultOptions?.requestInterceptor(requestArgs);
+        }
+
+        // 요청에는 먼저 content type을 확인한다
+        //
+        const fetchResponse = await fetch(url, {
+          method: 'get',
+          body: requestArgs.data,
+        }); // 수정 필요 현재는 response interceptor을 위한 임의 값
+
+        let response = await processResponse(
+          fetchResponse,
+          requestArgs.responseType,
+        );
+
         // 요청 값 반환
       },
       post(): any {},

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,18 +1,3 @@
-// // Prepare the response
-// const responseHeaders = AxiosHeaders.from(
-//   'getAllResponseHeaders' in request && request.getAllResponseHeaders()
-// );
-// const responseData = !responseType || responseType === 'text' || responseType === 'json' ?
-//   request.responseText : request.response;
-// const response = {
-//   data: responseData,
-//   status: request.status,
-//   statusText: request.statusText,
-//   headers: responseHeaders,
-//   config, // AxiosRequestConfig에 header만 추가된 타입
-//   request // axios 공식 문서를 보면 응답을 생성한 요청이라는데 어디에 사용되는지 모르겠음
-// };
-
 export type NextFetchResponse<T = any> = {
   data: ResponseDataType<T>;
   status: number;
@@ -130,12 +115,16 @@ export const nextFetch = {
 
         // 요청에는 먼저 content type을 확인한다
         //
-        const fetchResponse = await fetch(url, {
+        let fetchResponse = await fetch(url, {
           method: 'get',
           body: requestArgs.data,
         }); // 수정 필요 현재는 response interceptor을 위한 임의 값
 
-        let response = await processResponse<T>(
+        if (requestArgs.responseInterceptor) {
+          fetchResponse = await requestArgs.responseInterceptor(fetchResponse);
+        } // interceptor 실행
+
+        const response = await processResponse<T>(
           fetchResponse,
           requestArgs.responseType,
         );

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
-type NextFetchResponse<T extends ResponseType, D = any> = {
-  data: ResponseData<T, D>;
+type Nextresponse<T = any> = {
+  data: T;
   status: number;
   statusText: string;
   headers: Headers;
@@ -12,18 +12,6 @@ type ResponseType =
   | 'text'
   | 'stream'
   | 'formdata';
-
-type ResponseData<T extends ResponseType, D = any> = T extends 'arraybuffer'
-  ? ArrayBuffer
-  : T extends 'blob'
-    ? Blob
-    : T extends 'json'
-      ? D
-      : T extends 'text'
-        ? string
-        : T extends 'formdata'
-          ? FormData
-          : ReadableStream<Uint8Array> | null;
 
 export type NextFetchDefaultOptions = {
   /**
@@ -55,13 +43,7 @@ export type NextFetchDefaultOptions = {
    *
    * @public
    */
-  responseType?:
-    | 'arraybuffer'
-    | 'blob'
-    | 'json'
-    | 'text'
-    | 'stream'
-    | 'formdata';
+  responseType?: ResponseType;
   responseInterceptor?: (response: Response) => Promise<Response>;
   /**
    * Request Interceptor of fetch. It will be called before request
@@ -71,75 +53,69 @@ export type NextFetchDefaultOptions = {
   requestInterceptor?: (requestArg: RequestInit) => Promise<RequestInit>;
 };
 
-const processResponse = async <T extends ResponseType, D = any>(
-  fetchResponse: Response,
+// return response로 가공하는 함수
+const processReturnResponse = async <T = any>(
+  response: Response,
   responseType: ResponseType,
-): Promise<NextFetchResponse<T, D>> => {
-  let data: ResponseData<T, D>;
+) => {
+  let data: T;
   switch (responseType) {
     case 'arraybuffer':
-      data = (await fetchResponse.arrayBuffer()) as ResponseData<T, D>;
+      data = (await response.arrayBuffer()) as T;
       break;
 
     case 'json':
-      data = (await fetchResponse.json()) as ResponseData<T, D>;
+      data = await response.json();
       break;
 
     case 'text':
-      data = (await fetchResponse.text()) as ResponseData<T, D>;
+      data = (await response.text()) as T;
       break;
 
     case 'formdata':
-      data = (await fetchResponse.formData()) as ResponseData<T, D>;
+      data = (await response.formData()) as T;
       break;
 
     case 'blob':
-      data = (await fetchResponse.blob()) as ResponseData<T, D>;
+      data = (await response.blob()) as T;
       break;
 
     default:
-      data = fetchResponse.body as ResponseData<T, D>;
+      data = response.body as T;
       break;
     // stream일 때 이게 맞는지?
   }
   return {
     data,
-    status: fetchResponse.status,
-    statusText: fetchResponse.statusText,
-    headers: fetchResponse.headers,
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
   };
 };
 
 export const nextFetch = {
   create: (defaultOptions?: NextFetchDefaultOptions) => {
     const instance = {
-      async get<T extends ResponseType>(
-        url: string | URL,
-        ...args: Parameters<typeof fetch>
-      ): Promise<NextFetchResponse<T>> {
+      async get<T = any>(url: string | URL): Promise<Nextresponse<T>> {
         // default options를 가지고 options 만들기
         let requestArgs: any;
-        if (defaultOptions?.requestInterceptor) {
-          requestArgs = await defaultOptions?.requestInterceptor(requestArgs);
-        }
 
         // 요청에는 먼저 content type을 확인한다
         //
-        let fetchResponse = await fetch(url, {
+        let response = await fetch(url, {
           method: 'get',
-          body: requestArgs.data,
         }); // 수정 필요 현재는 response interceptor을 위한 임의 값
 
         if (requestArgs.responseInterceptor) {
-          fetchResponse = await requestArgs.responseInterceptor(fetchResponse);
+          response = await requestArgs.responseInterceptor(response);
         } // interceptor 실행
 
-        const response = await processResponse<T>(
-          fetchResponse,
+        const returnResponse = await processReturnResponse<T>(
+          response,
           requestArgs.responseType,
         );
 
-        return response;
+        return returnResponse;
 
         // 요청 값 반환
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,19 +75,12 @@ export type NextFetchDefaultOptions = {
   requestInterceptor?: (requestArg: RequestInit) => Promise<RequestInit>;
 };
 
-const getContentType = (responseHeaders: Headers) => {
-  return responseHeaders.get('Content-Type') as string; // content-type이 없는 경우를 고려 X ....
-};
 const processResponse = async <T = any>(
   fetchResponse: Response,
   responseType: NextFetchDefaultOptions['responseType'],
 ): Promise<NextFetchResponse<T>> => {
-  let type = responseType
-    ? responseType
-    : getContentType(fetchResponse.headers);
-
   let data: ResponseDataType<T>;
-  switch (type) {
+  switch (responseType) {
     case 'arraybuffer':
       data = await fetchResponse.arrayBuffer();
       break;

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,6 +106,7 @@ export const nextFetch = {
           method: 'get',
         }); // 수정 필요 현재는 response interceptor을 위한 임의 값
 
+        httpErrorHandling(response);
         if (requestArgs.responseInterceptor) {
           response = await requestArgs.responseInterceptor(response);
         } // interceptor 실행


### PR DESCRIPTION
## **📌** 작업 내용
close #5 
 <!-- 이미지 존재하는 경우 함께 표시 해주세요 -->

> 구현 내용 및 작업 했던 내역

- [x] response를 받아서 returnResponse로 가공 
- [X] http status code가 300번대 이상이면 error throw
- [X] interceptor 실행
- [X] 예시 코드 실행 및 commit lint에 example 추가 
- [X] 사용자가 지정한 데이터 타입대로 반환해주기 (axios와 비슷하게)

## 🤔 고민 했던 부분

-  기존 로직은 아래와 같습니다
1. response type을 확인한다
2. response type의 값이 없으면 content-type을 확인해서 어떤 함수를 호출할 것인지 결정한다 ( blob() , text() , json() )

위 로직에는 content-type만으로 어떤 함수를 호출할 것인지 판단할 수 없는 에러가 존재했습니다
예를 들어 text/html content-type 같은 경우엔 response.json()은 불가하지만, response.blob()이나 response.text() 둘 다 가능합니다

그러면 content-type만을 가지고 판단할 수 없다고 생각했고 다음 로직으로 구현했습니다
1. response type을 확인한다
2. response type이 존재하지 않으면 axios처럼 default값인 json으로 판단해 response.json()을 호출한다
3. response type이 정해져있으면 그 타입에 맞는 함수를 호출한다
