### PR TITLE
fix request options 

### DIFF
--- a/examples/baseURL.ts
+++ b/examples/baseURL.ts
@@ -1,0 +1,10 @@
+import { nextFetch } from '../src';
+
+// set baseUrl
+const instance = nextFetch.create({
+  baseURL: 'http://localhost:3000',
+});
+
+const basicResponse = instance.get('/');
+
+const responseWithChangedUrl = instance.get('http://localhost:3001/');

--- a/examples/error-handling.ts
+++ b/examples/error-handling.ts
@@ -1,0 +1,11 @@
+import { nextFetch } from '../src';
+
+const instance = nextFetch.create({ throwError: true });
+
+// error handling will not apply
+const errorHandlingFalseResponse = instance.get('/', { throwError: false });
+
+// error handling will apply
+try {
+  const errorHandlingTrueResponse = instance.get('/');
+} catch (error) {}

--- a/examples/headers.ts
+++ b/examples/headers.ts
@@ -1,0 +1,18 @@
+import { nextFetch } from '../src';
+
+// Content-Type default value is application-json
+// But Content-Type value changed due to default options
+const instance = nextFetch.create({
+  headers: {
+    'Content-Type': 'text/plain',
+  },
+});
+
+const response = instance.get('/');
+
+// Content-Type value changed due to request init
+const responseWithChangedHeaders = instance.get('/', {
+  headers: {
+    'Content-Type': 'multipart/formed-data',
+  },
+});

--- a/examples/interceptor.ts
+++ b/examples/interceptor.ts
@@ -1,0 +1,30 @@
+import { nextFetch } from '../src';
+
+const instance = nextFetch.create({
+  responseInterceptor: (response: Response) => {
+    console.log('default options response interceptor');
+    return response;
+  },
+  requestInterceptor: (requestArg: RequestInit) => {
+    console.log('default options reqeust interceptor');
+    return requestArg;
+  },
+});
+
+// The console is printed in the following order
+/*
+default options reqeust interceptor
+requestInit reqeust interceptor
+default options response interceptor
+requestInit response interceptor
+ */
+const response = instance.get('/', {
+  requestInterceptor: (requestArg: RequestInit) => {
+    console.log('requestInit reqeust interceptor');
+    return requestArg;
+  },
+  responseInterceptor: (response: Response) => {
+    console.log('requestInit response interceptor');
+    return response;
+  },
+});

--- a/examples/responseType.ts
+++ b/examples/responseType.ts
@@ -1,0 +1,12 @@
+import { nextFetch } from '../src';
+
+// response type default value is json
+const instance = nextFetch.create();
+
+// response data will apply json parse
+const response = instance.get('/');
+
+// response data type is form data
+const responseWithChangedResponseType = instance.get('/', {
+  responseType: 'formdata',
+});

--- a/examples/type.ts
+++ b/examples/type.ts
@@ -1,8 +1,0 @@
-import { nextFetch } from '../src';
-
-// 사용자가 설정한 타입이 데이터 타입으로 잘 오는지 확인
-const fetch = nextFetch.create({ responseType: 'json' });
-const a = await fetch.get<{
-  zpp: number;
-}>('http://localhost:3001/json');
-console.log(a.data);

--- a/src/index.ts
+++ b/src/index.ts
@@ -197,6 +197,12 @@ const applyDefaultOptionsArgs = (
     headers: requestHeaders,
   };
 
+  if (!requestArgs.throwError) {
+    requestArgs.throwError = defaultOptions?.throwError
+      ? defaultOptions?.throwError
+      : false;
+  }
+
   if (defaultOptions?.requestInterceptor) {
     requestArgs = defaultOptions.requestInterceptor(requestArgs);
   }
@@ -224,7 +230,11 @@ export const nextFetch = {
           method: 'GET',
         });
 
-        httpErrorHandling(response);
+        if (requestArgs?.throwError) httpErrorHandling(response);
+
+        if (defaultOptions?.responseInterceptor) {
+          response = await defaultOptions.responseInterceptor(response);
+        }
         if (requestArgs?.responseInterceptor) {
           response = await requestArgs.responseInterceptor(response);
         }
@@ -251,11 +261,14 @@ export const nextFetch = {
           body: requestArgs?.data ? (requestArgs.data as BodyInit) : null,
         });
 
-        httpErrorHandling(response);
+        if (requestArgs?.throwError) httpErrorHandling(response);
+
+        if (defaultOptions?.responseInterceptor) {
+          response = await defaultOptions.responseInterceptor(response);
+        }
         if (requestArgs?.responseInterceptor) {
           response = await requestArgs.responseInterceptor(response);
         }
-
         const returnResponse = await processReturnResponse<T>(
           response,
           requestArgs?.responseType,
@@ -278,7 +291,11 @@ export const nextFetch = {
           body: requestArgs?.data ? (requestArgs.data as BodyInit) : null,
         });
 
-        httpErrorHandling(response);
+        if (requestArgs?.throwError) httpErrorHandling(response);
+
+        if (defaultOptions?.responseInterceptor) {
+          response = await defaultOptions.responseInterceptor(response);
+        }
         if (requestArgs?.responseInterceptor) {
           response = await requestArgs.responseInterceptor(response);
         }
@@ -304,7 +321,11 @@ export const nextFetch = {
           method: 'DELETE',
         });
 
-        httpErrorHandling(response);
+        if (requestArgs?.throwError) httpErrorHandling(response);
+
+        if (defaultOptions?.responseInterceptor) {
+          response = await defaultOptions.responseInterceptor(response);
+        }
         if (requestArgs?.responseInterceptor) {
           response = await requestArgs.responseInterceptor(response);
         }
@@ -331,7 +352,11 @@ export const nextFetch = {
           body: requestArgs?.data ? (requestArgs.data as BodyInit) : null,
         });
 
-        httpErrorHandling(response);
+        if (requestArgs?.throwError) httpErrorHandling(response);
+
+        if (defaultOptions?.responseInterceptor) {
+          response = await defaultOptions.responseInterceptor(response);
+        }
         if (requestArgs?.responseInterceptor) {
           response = await requestArgs.responseInterceptor(response);
         }
@@ -357,11 +382,14 @@ export const nextFetch = {
           method: 'HEAD',
         });
 
-        httpErrorHandling(response);
+        if (requestArgs?.throwError) httpErrorHandling(response);
+
+        if (defaultOptions?.responseInterceptor) {
+          response = await defaultOptions.responseInterceptor(response);
+        }
         if (requestArgs?.responseInterceptor) {
           response = await requestArgs.responseInterceptor(response);
         }
-
         const returnResponse = await processReturnResponse<T>(
           response,
           requestArgs?.responseType,

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,7 +115,7 @@ interface RequestInit {
   /** A string indicating whether credentials will be sent with the request always, never, or only when sent to a same-origin URL. Sets request's credentials. */
   credentials?: RequestCredentials;
   /** A Headers object, an object literal, or an array of two-item arrays to set request's headers. */
-  headers: Headers;
+  headers?: Headers;
   /** A cryptographic hash of the resource to be fetched by request. Sets request's integrity. */
   integrity?: string;
   /** A boolean to set request's keepalive. */
@@ -143,6 +143,31 @@ interface RequestInit {
   responseType?: ResponseType;
 }
 
+const isArrayBufferView = (data: any): data is ArrayBufferView => {
+  return (
+    data &&
+    typeof data === 'object' &&
+    'buffer' in data &&
+    data.buffer instanceof ArrayBuffer &&
+    'byteLength' in data &&
+    typeof data.byteLength === 'number' &&
+    'byteOffset' in data &&
+    typeof data.byteOffset === 'number'
+  );
+};
+
+const isBodyInit = (data: any): data is BodyInit => {
+  return (
+    typeof data === 'string' ||
+    data instanceof ReadableStream ||
+    data instanceof Blob ||
+    data instanceof ArrayBuffer ||
+    data instanceof FormData ||
+    data instanceof URLSearchParams ||
+    isArrayBufferView(data)
+  );
+};
+
 const applyDefaultOptionsArgs = (
   [url, requestInit]: FetchArgs,
   defaultOptions?: NextFetchDefaultOptions,
@@ -163,14 +188,7 @@ const applyDefaultOptionsArgs = (
     });
   }
 
-  if (
-    requestInit?.data &&
-    requestHeaders.get('Content-Type') === 'application/json'
-  ) {
-    requestInit.data = JSON.stringify(requestInit.data);
-  }
-
-  let requestArgs = {
+  let requestArgs: RequestInit = {
     ...defaultOptions,
     ...requestInit,
     headers: requestHeaders,

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,7 +109,7 @@ interface RequestInit {
   /** next fetch does not have a method attribute because it has http request method. */
 
   /** A BodyInit object or null to set request's body. */
-  data?: BodyInit;
+  data?: BodyInit | Record<string, any>;
   /** A string indicating how the request will interact with the browser's cache to set request's cache. */
   cache?: RequestCache;
   /** A string indicating whether credentials will be sent with the request always, never, or only when sent to a same-origin URL. Sets request's credentials. */
@@ -188,6 +188,9 @@ const applyDefaultOptionsArgs = (
     });
   }
 
+  if (requestInit?.data && !isBodyInit(requestInit?.data)) {
+    requestInit.data = JSON.stringify(requestInit.data);
+  }
   let requestArgs: RequestInit = {
     ...defaultOptions,
     ...requestInit,
@@ -245,7 +248,7 @@ export const nextFetch = {
         let response = await fetch(requestUrl, {
           ...requestArgs,
           method: 'POST',
-          body: requestArgs?.data ? requestArgs.data : null,
+          body: requestArgs?.data ? (requestArgs.data as BodyInit) : null,
         });
 
         httpErrorHandling(response);
@@ -272,7 +275,7 @@ export const nextFetch = {
         let response = await fetch(requestUrl, {
           ...requestArgs,
           method: 'PUT',
-          body: requestArgs?.data ? requestArgs.data : null,
+          body: requestArgs?.data ? (requestArgs.data as BodyInit) : null,
         });
 
         httpErrorHandling(response);
@@ -325,7 +328,7 @@ export const nextFetch = {
         let response = await fetch(requestUrl, {
           ...requestArgs,
           method: 'PATCH',
-          body: requestArgs?.data ? requestArgs.data : null,
+          body: requestArgs?.data ? (requestArgs.data as BodyInit) : null,
         });
 
         httpErrorHandling(response);

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,7 +115,7 @@ interface RequestInit {
   /** A string indicating whether credentials will be sent with the request always, never, or only when sent to a same-origin URL. Sets request's credentials. */
   credentials?: RequestCredentials;
   /** A Headers object, an object literal, or an array of two-item arrays to set request's headers. */
-  headers?: Headers;
+  headers?: HeadersInit;
   /** A cryptographic hash of the resource to be fetched by request. Sets request's integrity. */
   integrity?: string;
   /** A boolean to set request's keepalive. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -163,6 +163,13 @@ const applyDefaultOptionsArgs = (
     });
   }
 
+  if (
+    requestInit?.data &&
+    requestHeaders.get('Content-Type') === 'application/json'
+  ) {
+    requestInit.data = JSON.stringify(requestInit.data);
+  }
+
   let requestArgs = {
     ...defaultOptions,
     ...requestInit,


### PR DESCRIPTION
## **📌** 작업 내용

 <!-- 이미지 존재하는 경우 함께 표시 해주세요 -->

> 구현 내용 및 작업 했던 내역

- [x] headers 오류 수정
- [X] body init 타입 오류 수정  
- [X] response interceptor 수정( defaultOptions, requestInit 의 interceptor 모두 실행 )
- [X] throwError 여부에 따른 error handling으로 수정
- [X] 각 default options 별 playground 수정 (ofetch 참고)

## 🤔 고민 했던 부분

- headers가 필수값으로 들어가있길래 undefined도 들어올 수 있도록 수정했습니다

- fetch 요청 시에는 BodyInit 타입이어야하고 nextFetch에서 args를 파라미터로 받을때는 BodyInit 타입 뿐만 아니라 Record<string,any> 타입을 함께 받아야 하고 로직은 다음과 같습니다
- 1. 객체를 arg로 BodyInit | Record<string,any> 타입을 받음 
- 2. BodyInit 타입이 아니면 JsonStringify를 통해 JSON으로 변경
- 3. fetch 요청시 BodyInit 타입을 할당 
결과적으로는 JSON stringify를 통해 BodyInIt 타입에 성립하므로 as를 사용하여 타입을 단언시켰는데 
확실한 방법인지 모르겠습니다. 테스트 부탁드립니다
또한 더 좋은 방법이 있으면 의견 주시면 감사하겠습니다