### PR TITLE
에러 발생 시 동작하는 인터셉터 구현

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -360,7 +360,8 @@ const fetchAX = {
           method: 'DELETE',
         });
 
-        if (requestArgs?.throwError) httpErrorHandling(response);
+        if (requestArgs?.throwError || isHttpError(response))
+          return await httpErrorHandling(response, defaultOptions, requestArgs);
 
         if (defaultOptions?.responseInterceptor) {
           response = await defaultOptions.responseInterceptor(response);

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,13 +11,10 @@ export class fetchAxError extends Error {
 
 export const httpErrorHandling = async (
   response: Response,
-  defaultOptions?: FetchAXDefaultOptions,
   requestArgs?: RequestInit,
 ) => {
   let error = new fetchAxError(response.status, response);
-  if (defaultOptions?.responseRejectedInterceptor) {
-    error = await defaultOptions.responseRejectedInterceptor(error);
-  }
+
   if (requestArgs?.responseRejectedInterceptor) {
     error = await requestArgs.responseRejectedInterceptor(error);
   }
@@ -80,7 +77,7 @@ export type FetchAXDefaultOptions = {
    *
    * @public
    */
-  responseRejectedInterceptor?: (error: fetchAxError) => any;
+  responseRejectedInterceptor?: (error: any) => any;
 
   /**
    * Request Interceptor of fetch. It will be called before request
@@ -168,7 +165,7 @@ export interface RequestInit {
   /** Response Interceptor of fetch. It will be called after response */
   responseInterceptor?: (response: Response) => Response | Promise<Response>;
   /** Response Interceptor of fetch. It will be called after response When the status is 300 or more */
-  responseRejectedInterceptor?: (error: fetchAxError) => any;
+  responseRejectedInterceptor?: (error: any) => any;
   /** Request Interceptor of fetch. It will be called before request */
   requestInterceptor?: (requestArg: RequestInit) => RequestInit;
   /** Throw Error of fetch. If the throwError attribute is true, throw an error when the status is 300 or more */
@@ -288,7 +285,7 @@ const fetchAX = {
         });
 
         if (requestArgs?.throwError || isHttpError(response))
-          return await httpErrorHandling(response, defaultOptions, requestArgs);
+          return await httpErrorHandling(response, requestArgs);
 
         if (defaultOptions?.responseInterceptor) {
           response = await defaultOptions.responseInterceptor(response);
@@ -320,7 +317,7 @@ const fetchAX = {
         });
 
         if (requestArgs?.throwError || isHttpError(response))
-          return await httpErrorHandling(response, defaultOptions, requestArgs);
+          return await httpErrorHandling(response, requestArgs);
 
         if (defaultOptions?.responseInterceptor) {
           response = await defaultOptions.responseInterceptor(response);
@@ -381,7 +378,7 @@ const fetchAX = {
         });
 
         if (requestArgs?.throwError || isHttpError(response))
-          return await httpErrorHandling(response, defaultOptions, requestArgs);
+          return await httpErrorHandling(response, requestArgs);
 
         if (defaultOptions?.responseInterceptor) {
           response = await defaultOptions.responseInterceptor(response);
@@ -413,7 +410,7 @@ const fetchAX = {
         });
 
         if (requestArgs?.throwError || isHttpError(response))
-          return await httpErrorHandling(response, defaultOptions, requestArgs);
+          return await httpErrorHandling(response, requestArgs);
 
         if (defaultOptions?.responseInterceptor) {
           response = await defaultOptions.responseInterceptor(response);
@@ -444,7 +441,7 @@ const fetchAX = {
         })) as unknown as Response;
 
         if (requestArgs?.throwError || isHttpError(response))
-          return await httpErrorHandling(response, defaultOptions, requestArgs);
+          return await httpErrorHandling(response, requestArgs);
 
         if (defaultOptions?.responseInterceptor) {
           response = await defaultOptions.responseInterceptor(response);

--- a/src/index.ts
+++ b/src/index.ts
@@ -423,7 +423,8 @@ const fetchAX = {
           method: 'HEAD',
         })) as unknown as Response;
 
-        if (requestArgs?.throwError) httpErrorHandling(response);
+        if (requestArgs?.throwError || isHttpError(response))
+          return await httpErrorHandling(response, defaultOptions, requestArgs);
 
         if (defaultOptions?.responseInterceptor) {
           response = await defaultOptions.responseInterceptor(response);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-class fetchAxError extends Error {
+export class fetchAxError extends Error {
   constructor(
     readonly statusCode: number,
     readonly response: Response,
@@ -62,6 +62,13 @@ export type FetchAXDefaultOptions = {
    * @public
    */
   responseInterceptor?: (response: Response) => Response | Promise<Response>;
+
+  /**
+   * Response Interceptor of fetch. It will be called after response When the status is 300 or more
+   *
+   * @public
+   */
+  responseRejectedInterceptor?: (error: fetchAxError) => any;
 
   /**
    * Response Interceptor of fetch. It will be called after response

--- a/src/index.ts
+++ b/src/index.ts
@@ -155,6 +155,8 @@ export interface RequestInit {
   window?: null;
   /** Response Interceptor of fetch. It will be called after response */
   responseInterceptor?: (response: Response) => Response | Promise<Response>;
+  /** Response Interceptor of fetch. It will be called after response When the status is 300 or more */
+  responseRejectedInterceptor?: (error: fetchAxError) => any;
   /** Request Interceptor of fetch. It will be called before request */
   requestInterceptor?: (requestArg: RequestInit) => RequestInit;
   /** Throw Error of fetch. If the throwError attribute is true, throw an error when the status is 300 or more */

--- a/src/index.ts
+++ b/src/index.ts
@@ -392,7 +392,8 @@ const fetchAX = {
           body: requestArgs?.data ? (requestArgs.data as BodyInit) : null,
         });
 
-        if (requestArgs?.throwError) httpErrorHandling(response);
+        if (requestArgs?.throwError || isHttpError(response))
+          return await httpErrorHandling(response, defaultOptions, requestArgs);
 
         if (defaultOptions?.responseInterceptor) {
           response = await defaultOptions.responseInterceptor(response);

--- a/src/index.ts
+++ b/src/index.ts
@@ -252,7 +252,7 @@ const fetchAX = {
           method: 'GET',
         });
 
-        if (requestArgs?.throwError) httpErrorHandling(response);
+          return await httpErrorHandling(response, defaultOptions, requestArgs);
 
         if (defaultOptions?.responseInterceptor) {
           response = await defaultOptions.responseInterceptor(response);

--- a/src/index.ts
+++ b/src/index.ts
@@ -288,7 +288,7 @@ const fetchAX = {
           method: 'GET',
         });
 
-        if (requestArgs?.throwError || isHttpError(response))
+        if (requestArgs?.throwError && isHttpError(response))
           return await httpErrorHandling(response, requestArgs);
 
         if (requestArgs?.responseInterceptor) {
@@ -317,7 +317,7 @@ const fetchAX = {
           body: requestArgs?.data ? (requestArgs.data as BodyInit) : null,
         });
 
-        if (requestArgs?.throwError || isHttpError(response))
+        if (requestArgs?.throwError && isHttpError(response))
           return await httpErrorHandling(response, requestArgs);
 
         if (requestArgs?.responseInterceptor) {
@@ -345,7 +345,7 @@ const fetchAX = {
           body: requestArgs?.data ? (requestArgs.data as BodyInit) : null,
         });
 
-        if (requestArgs?.throwError || isHttpError(response))
+        if (requestArgs?.throwError && isHttpError(response))
           return await httpErrorHandling(response, requestArgs);
 
         if (requestArgs?.responseInterceptor) {
@@ -373,7 +373,7 @@ const fetchAX = {
           method: 'DELETE',
         });
 
-        if (requestArgs?.throwError || isHttpError(response))
+        if (requestArgs?.throwError && isHttpError(response))
           return await httpErrorHandling(response, requestArgs);
 
         if (requestArgs?.responseInterceptor) {
@@ -402,7 +402,7 @@ const fetchAX = {
           body: requestArgs?.data ? (requestArgs.data as BodyInit) : null,
         });
 
-        if (requestArgs?.throwError || isHttpError(response))
+        if (requestArgs?.throwError && isHttpError(response))
           return await httpErrorHandling(response, requestArgs);
 
         if (requestArgs?.responseInterceptor) {
@@ -430,7 +430,7 @@ const fetchAX = {
           method: 'HEAD',
         })) as unknown as Response;
 
-        if (requestArgs?.throwError || isHttpError(response))
+        if (requestArgs?.throwError && isHttpError(response))
           return await httpErrorHandling(response, requestArgs);
 
         if (requestArgs?.responseInterceptor) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,7 +57,7 @@ export type FetchAXDefaultOptions = {
 
   responseType?: ResponseType;
   /**
-   * Request Interceptor of fetch. It will be called before request
+   * Response Interceptor of fetch. It will be called after response
    *
    * @public
    */
@@ -71,7 +71,7 @@ export type FetchAXDefaultOptions = {
   responseRejectedInterceptor?: (error: fetchAxError) => any;
 
   /**
-   * Response Interceptor of fetch. It will be called after response
+   * Request Interceptor of fetch. It will be called before request
    *
    * @public
    */

--- a/src/index.ts
+++ b/src/index.ts
@@ -253,7 +253,7 @@ const applyDefaultOptionsArgs = (
 };
 
 function isHttpError(response: Response) {
-  return response.status >= 300 ? true : false;
+  return response.status >= 300;
 }
 
 function chainInterceptor<T>(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export class fetchAxError extends Error {
+export class FetchAxError extends Error {
   constructor(
     readonly statusCode: number,
     readonly response: Response,
@@ -13,7 +13,7 @@ export const httpErrorHandling = async (
   response: Response,
   requestArgs?: RequestInit,
 ) => {
-  let error = new fetchAxError(response.status, response);
+  let error = new FetchAxError(response.status, response);
 
   if (requestArgs?.responseRejectedInterceptor) {
     error = await requestArgs.responseRejectedInterceptor(error);

--- a/src/index.ts
+++ b/src/index.ts
@@ -233,6 +233,7 @@ const applyDefaultOptionsArgs = (
 
   return [requestUrl, requestArgs];
 };
+function isHttpError(response: Response) {
 
 const fetchAX = {
   create: (defaultOptions?: FetchAXDefaultOptions) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -267,7 +267,6 @@ const fetchAX = {
           method: 'GET',
         });
 
-        // if (requestArgs?.throwError) httpErrorHandling(response);
         if (requestArgs?.throwError || isHttpError(response))
           return await httpErrorHandling(response, defaultOptions, requestArgs);
 
@@ -300,7 +299,8 @@ const fetchAX = {
           body: requestArgs?.data ? (requestArgs.data as BodyInit) : null,
         });
 
-        if (requestArgs?.throwError) httpErrorHandling(response);
+        if (requestArgs?.throwError || isHttpError(response))
+          return await httpErrorHandling(response, defaultOptions, requestArgs);
 
         if (defaultOptions?.responseInterceptor) {
           response = await defaultOptions.responseInterceptor(response);

--- a/src/index.ts
+++ b/src/index.ts
@@ -240,6 +240,10 @@ const applyDefaultOptionsArgs = (
     requestArgs = requestInit.requestInterceptor(requestArgs);
   }
 
+  requestArgs.responseInterceptor = chainInterceptor(
+    defaultOptions?.responseInterceptor,
+    requestInit?.responseInterceptor,
+  );
   requestArgs.responseRejectedInterceptor = chainInterceptor(
     defaultOptions?.responseRejectedInterceptor,
     requestInit?.responseRejectedInterceptor,
@@ -287,9 +291,6 @@ const fetchAX = {
         if (requestArgs?.throwError || isHttpError(response))
           return await httpErrorHandling(response, requestArgs);
 
-        if (defaultOptions?.responseInterceptor) {
-          response = await defaultOptions.responseInterceptor(response);
-        }
         if (requestArgs?.responseInterceptor) {
           response = await requestArgs.responseInterceptor(response);
         }
@@ -319,9 +320,6 @@ const fetchAX = {
         if (requestArgs?.throwError || isHttpError(response))
           return await httpErrorHandling(response, requestArgs);
 
-        if (defaultOptions?.responseInterceptor) {
-          response = await defaultOptions.responseInterceptor(response);
-        }
         if (requestArgs?.responseInterceptor) {
           response = await requestArgs.responseInterceptor(response);
         }
@@ -350,9 +348,6 @@ const fetchAX = {
         if (requestArgs?.throwError || isHttpError(response))
           return await httpErrorHandling(response, requestArgs);
 
-        if (defaultOptions?.responseInterceptor) {
-          response = await defaultOptions.responseInterceptor(response);
-        }
         if (requestArgs?.responseInterceptor) {
           response = await requestArgs.responseInterceptor(response);
         }
@@ -381,9 +376,6 @@ const fetchAX = {
         if (requestArgs?.throwError || isHttpError(response))
           return await httpErrorHandling(response, requestArgs);
 
-        if (defaultOptions?.responseInterceptor) {
-          response = await defaultOptions.responseInterceptor(response);
-        }
         if (requestArgs?.responseInterceptor) {
           response = await requestArgs.responseInterceptor(response);
         }
@@ -413,9 +405,6 @@ const fetchAX = {
         if (requestArgs?.throwError || isHttpError(response))
           return await httpErrorHandling(response, requestArgs);
 
-        if (defaultOptions?.responseInterceptor) {
-          response = await defaultOptions.responseInterceptor(response);
-        }
         if (requestArgs?.responseInterceptor) {
           response = await requestArgs.responseInterceptor(response);
         }
@@ -444,9 +433,6 @@ const fetchAX = {
         if (requestArgs?.throwError || isHttpError(response))
           return await httpErrorHandling(response, requestArgs);
 
-        if (defaultOptions?.responseInterceptor) {
-          response = await defaultOptions.responseInterceptor(response);
-        }
         if (requestArgs?.responseInterceptor) {
           response = await requestArgs.responseInterceptor(response);
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -347,7 +347,8 @@ const fetchAX = {
           body: requestArgs?.data ? (requestArgs.data as BodyInit) : null,
         });
 
-        if (requestArgs?.throwError) httpErrorHandling(response);
+        if (requestArgs?.throwError || isHttpError(response))
+          return await httpErrorHandling(response, requestArgs);
 
         if (defaultOptions?.responseInterceptor) {
           response = await defaultOptions.responseInterceptor(response);

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -223,6 +223,29 @@ describe('next-fetch-error', () => {
         });
       }
     });
+
+    it('return promise custom error', async () => {
+      const instance = fetchAX.create({
+        throwError: true,
+        responseRejectedInterceptor: (error) => {
+          if (error.statusCode === 300) {
+            return Promise.reject(
+              new BadRequestError({
+                message: 'Bad Request',
+                response: error.response,
+              }),
+            );
+          }
+        },
+      });
+
+      try {
+        await instance.get('https://jsonplaceholder.typicode.com/Error/1');
+      } catch (error) {
+        expect(error).toBeInstanceOf(BadRequestError);
+        expect(error.message).toBe('Bad Request');
+      }
+    });
   });
 });
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,4 +1,4 @@
-import { default as fetchAX, fetchAxError, RequestInit } from '../src';
+import { default as fetchAX, FetchAxError, RequestInit } from '../src';
 
 describe('next-fetch', () => {
   const globalFetch = global.fetch;
@@ -183,7 +183,7 @@ describe('next-fetch-error', () => {
     }
 
     // then
-    expect(error).toBeInstanceOf(fetchAxError);
+    expect(error).toBeInstanceOf(FetchAxError);
   });
 });
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -204,7 +204,7 @@ describe('next-fetch-error', () => {
         });
       }
     });
-
+  });
 });
 
 class HttpError extends Error {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -246,6 +246,27 @@ describe('next-fetch-error', () => {
         expect(error.message).toBe('Bad Request');
       }
     });
+
+    it('throw promise custom error', async () => {
+      const instance = fetchAX.create({
+        throwError: true,
+        responseRejectedInterceptor: (error) => {
+          if (error.statusCode === 300) {
+            throw new BadRequestError({
+              message: 'Bad Request',
+              response: error.response,
+            });
+          }
+        },
+      });
+
+      try {
+        await instance.get('https://jsonplaceholder.typicode.com/Error/1');
+      } catch (error) {
+        expect(error).toBeInstanceOf(BadRequestError);
+        expect(error.message).toBe('Bad Request');
+      }
+    });
   });
 });
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -204,6 +204,25 @@ describe('next-fetch-error', () => {
         });
       }
     });
+
+    it('throw reject error', async () => {
+      const instance = fetchAX.create({
+        throwError: true,
+        responseRejectedInterceptor: (error) => {
+          if (error.statusCode === 300) {
+            throw { error: 'error' };
+          }
+        },
+      });
+
+      try {
+        await instance.get('https://jsonplaceholder.typicode.com/Error/1');
+      } catch (error) {
+        expect(error).toEqual({
+          error: 'error',
+        });
+      }
+    });
   });
 });
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -210,6 +210,7 @@ describe('interceptor', () => {
     });
 
     it('should return response', async () => {
+      // given
       const instance = fetchAX.create({
         responseType: 'json',
         responseInterceptor: (response) => {
@@ -217,10 +218,12 @@ describe('interceptor', () => {
         },
       });
 
+      // when
       const response = await instance.get(
         'https://jsonplaceholder.typicode.com/todos/1',
       );
 
+      // then
       expect(response.data).toEqual({
         userId: 1,
         id: 1,
@@ -252,6 +255,7 @@ describe('interceptor', () => {
     });
 
     it('return promise reject error', async () => {
+      // given
       const instance = fetchAX.create({
         throwError: true,
         responseRejectedInterceptor: (error) => {
@@ -262,8 +266,10 @@ describe('interceptor', () => {
       });
 
       try {
+        // when
         await instance.get('https://jsonplaceholder.typicode.com/Error/1');
       } catch (error) {
+        // then
         expect(error).toEqual({
           error: 'error',
         });
@@ -271,6 +277,7 @@ describe('interceptor', () => {
     });
 
     it('throw reject error', async () => {
+      // given
       const instance = fetchAX.create({
         throwError: true,
         responseRejectedInterceptor: (error) => {
@@ -281,8 +288,10 @@ describe('interceptor', () => {
       });
 
       try {
+        // when
         await instance.get('https://jsonplaceholder.typicode.com/Error/1');
       } catch (error) {
+        // theb
         expect(error).toEqual({
           error: 'error',
         });
@@ -290,6 +299,7 @@ describe('interceptor', () => {
     });
 
     it('return object', async () => {
+      // given
       const instance = fetchAX.create({
         throwError: true,
         responseRejectedInterceptor: (error) => {
@@ -300,8 +310,10 @@ describe('interceptor', () => {
       });
 
       try {
+        // when
         await instance.get('https://jsonplaceholder.typicode.com/Error/1');
       } catch (error) {
+        // then
         expect(error).toEqual({
           error: 'error',
         });
@@ -309,6 +321,7 @@ describe('interceptor', () => {
     });
 
     it('chain interceptor', async () => {
+      // given
       const instance = fetchAX.create({
         throwError: true,
         responseRejectedInterceptor: (error) => {
@@ -319,6 +332,7 @@ describe('interceptor', () => {
       });
 
       try {
+        // when
         await instance.get('https://jsonplaceholder.typicode.com/Error/1', {
           responseRejectedInterceptor: (error) => {
             if (error.error === 'chain') {
@@ -327,6 +341,7 @@ describe('interceptor', () => {
           },
         });
       } catch (error) {
+        // then
         expect(error).toEqual({
           error: 'chain-error',
         });
@@ -334,6 +349,7 @@ describe('interceptor', () => {
     });
 
     it('return promise custom error', async () => {
+      // given
       const instance = fetchAX.create({
         throwError: true,
         responseRejectedInterceptor: (error) => {
@@ -349,14 +365,17 @@ describe('interceptor', () => {
       });
 
       try {
+        // when
         await instance.get('https://jsonplaceholder.typicode.com/Error/1');
       } catch (error) {
+        // then
         expect(error).toBeInstanceOf(BadRequestError);
         expect(error.message).toBe('Bad Request');
       }
     });
 
     it('throw promise custom error', async () => {
+      // given
       const instance = fetchAX.create({
         throwError: true,
         responseRejectedInterceptor: (error) => {
@@ -370,8 +389,10 @@ describe('interceptor', () => {
       });
 
       try {
+        // when
         await instance.get('https://jsonplaceholder.typicode.com/Error/1');
       } catch (error) {
+        // then
         expect(error).toBeInstanceOf(BadRequestError);
         expect(error.message).toBe('Bad Request');
       }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -188,11 +188,47 @@ describe('next-fetch-error', () => {
 });
 
 describe('interceptor', () => {
-  // describe('response-interceptor', () => {
-  //   it('should return response', async () => {
+  describe('response-interceptor', () => {
+    let fetchMocked: jest.Mock;
+    const globalFetch = global.fetch;
 
-  //   });
-  // });
+    beforeEach(() => {
+      fetchMocked = jest.fn().mockResolvedValue({
+        json: jest.fn().mockResolvedValue({
+          userId: 1,
+          id: 1,
+          title: 'delectus aut autem',
+          completed: false,
+        }),
+      });
+
+      global.fetch = fetchMocked;
+    });
+    afterEach(() => {
+      // @ts-ignore
+      global.fetch = globalFetch;
+    });
+
+    it('should return response', async () => {
+      const instance = fetchAX.create({
+        responseType: 'json',
+        responseInterceptor: (response) => {
+          return response;
+        },
+      });
+
+      const response = await instance.get(
+        'https://jsonplaceholder.typicode.com/todos/1',
+      );
+
+      expect(response.data).toEqual({
+        userId: 1,
+        id: 1,
+        title: 'delectus aut autem',
+        completed: false,
+      });
+    });
+  });
 
   describe('response-rejected-interceptor', () => {
     const globalFetch = global.fetch;


### PR DESCRIPTION
## **📌** 작업 내용

> 구현 내용 및 작업 했던 내역

- [x]  에러 발생 시 동작하는 인터셉터 함수 responseRejectedInterceptor 인터페이스를 구현했습니다.
- [x]  responseRejectedInterceptor에 대한 테스트 코드를 작성했습니다.
- [x]  몇 가지 주석과 코드 에러를 수정했습니다.

## 🤔 고민 했던 부분

- 기존 인터셉터는 정상 응답값에 한해서만 동작하기 때문에 에러 발생 시 이를 공통적으로 처리할 수 있는 방법이 없었습니다. 에러 인터셉터는 상태 코드가 300 이상일 때 동작하며, 에러 처리 코드를 한 곳에서 일괄적으로 관리할 수 있습니다.

## 🔊 도움이 필요한 부분

- get, patch, put, post 등 요청 함수에 중복되는 로직이 있어서 이를 모듈화하면 좋겠다는 생각을 했습니다
