### PR TITLE
feat: next가 확장한 속성을 사용할 수 있도록 RequestInit가 globalThis를 타입을 확장

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -145,7 +145,7 @@ const processReturnResponse = async <T = any>(
  */
 export type FetchArgs = [string | URL, RequestInit | undefined];
 
-export interface RequestInit extends globalThis.RequestInit {
+export interface RequestInit extends Omit<globalThis.RequestInit, 'body'> {
   /** fetch-ax does not have a method attribute because it has http request method. */
 
   /** A BodyInit object or null to set request's body. */
@@ -511,6 +511,8 @@ export const presetOptions: FetchAXDefaultOptions = {
   throwError: true,
 
   responseType: 'json',
+
+  // baseURL: ''
 };
 export function mergeOptions(
   ...args: Record<string, any>[]

--- a/src/index.ts
+++ b/src/index.ts
@@ -145,7 +145,7 @@ const processReturnResponse = async <T = any>(
  */
 export type FetchArgs = [string | URL, RequestInit | undefined];
 
-export interface RequestInit {
+export interface RequestInit extends globalThis.RequestInit {
   /** fetch-ax does not have a method attribute because it has http request method. */
 
   /** A BodyInit object or null to set request's body. */
@@ -186,7 +186,6 @@ export interface RequestInit {
   /** data's type */
   responseType?: ResponseType;
 }
-
 const isArrayBufferView = (data: any): data is ArrayBufferView => {
   return (
     data &&


### PR DESCRIPTION
## **📌** 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] Next.js가 확장한 속성을 fetch-ax가 활용할 수 있도록 globalThis를 확장하는 방식으로 수정

## 🤔 고민 했던 부분
<img width="610" alt="스크린샷 2024-09-22 오후 6 40 14" src="https://github.com/user-attachments/assets/d725ff4c-3070-4e9e-a4b6-74a52ddd714a">
<img width="637" alt="스크린샷 2024-09-22 오후 6 40 36" src="https://github.com/user-attachments/assets/4916c243-5450-44b3-bd69-bec5c4ac9ee8">

- Next.js가 확장한 'next' 속성에 대한 타입이 fetch-ax에 없었습니다. 처음에는 단순히 RequestInit에 next 속성을 추가하여 업데이트하려 했습니다. 하지만 이 방법은 Next.js가 변경될 때마다 fetch-ax를 동기화해야 하는 문제를 야기했습니다. 이에 더 나은 해결책을 고민하게 되었습니다.
    - Next의 타입을 분석하던 중, Next가 fetch를 위해 global 타입을 확장해 속성을 추가하고 있음을 발견했습니다. 이를 바탕으로 fetch-ax도 Next가 재정의한 global 타입을 받아오면 될 것이라 판단하여, global 속성을 확장하도록 수정했습니다.
    - 베타 버전을 배포하여 테스트한 결과, 타입이 정상적으로 존재함을 확인했습니다.

<img width="562" alt="스크린샷 2024-09-22 오후 7 00 12" src="https://github.com/user-attachments/assets/4618497c-309f-4765-b2a9-e3d313e09e83">

<img width="612" alt="image" src="https://github.com/user-attachments/assets/6d2771e8-6e2e-40cb-aa15-6c2ee2dd1e18">


## 🔊 도움이 필요한 부분

