### PR TITLE
fix: fix Parsing Error & TypeError

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @yougyung @gahyuun
+* @yougyung @seonghunYang @gahyuun

--- a/README.md
+++ b/README.md
@@ -207,6 +207,8 @@ try {
 
 You can intercept requests or responses
 
+For requestInterceptor, the header of requestArgs is restricted to `Record<string,string>`. So we have to use RequestInitReturnedByInterceptor type
+
 ```tsx
 import fetchAX, { RequestInit } from '../src';
 
@@ -215,7 +217,7 @@ const instance = fetchAX.create({
     console.log('default options response interceptor');
     return response;
   },
-  requestInterceptor: (requestArg: RequestInit) => {
+  requestInterceptor: (requestArg: RequestInitReturnedByInterceptor) => {
     console.log('default options reqeust interceptor');
     return requestArg;
   },
@@ -226,10 +228,10 @@ const instance = fetchAX.create({
 default options reqeust interceptor
 requestInit reqeust interceptor
 default options response interceptor
-requestInit response interceptor
+requestInit response interceptor.
  */
 const response = instance.get('/', {
-  requestInterceptor: (requestArg: RequestInit) => {
+  requestInterceptor: (requestArg: RequestInitReturnedByInterceptor) => {
     console.log('requestInit reqeust interceptor');
     return requestArg;
   },
@@ -263,12 +265,12 @@ const instance = fetchAX.create({
 
 ### default options
 
-| Property                    | Description                              | Type                                                  | Default                                             |
-| --------------------------- | ---------------------------------------- | ----------------------------------------------------- | --------------------------------------------------- |
-| baseURL                     | base url                                 | string \| URL                                         | -                                                   |
-| headers                     | fetch headers                            | HeadersInit                                           | new Headers([['Content-Type', 'application/json']]) |
-| throwError                  | whether to throw an error                | boolean                                               | true                                                |
-| responseType                | response type to parse                   | ResponseType                                          | json                                                |
-| responseInterceptor         | interceptor to be executed on response   | (response: Response) => Response \| Promise<Response> | -                                                   |
-| responseRejectedInterceptor | interceptor to handle rejected responses | (error: any) => any                                   | -                                                   |
-| requestInterceptor          | interceptor to be executed on request    | (requestArg: RequestInit) => RequestInit              | -                                                   |
+| Property                    | Description                              | Type                                                                               | Default                                             |
+| --------------------------- | ---------------------------------------- | ---------------------------------------------------------------------------------- | --------------------------------------------------- |
+| baseURL                     | base url                                 | string \| URL                                                                      | -                                                   |
+| headers                     | fetch headers                            | HeadersInit                                                                        | new Headers([['Content-Type', 'application/json']]) |
+| throwError                  | whether to throw an error                | boolean                                                                            | true                                                |
+| responseType                | response type to parse                   | ResponseType                                                                       | json                                                |
+| responseInterceptor         | interceptor to be executed on response   | (response: Response) => Response \| Promise<Response>                              | -                                                   |
+| responseRejectedInterceptor | interceptor to handle rejected responses | (error: any) => any                                                                | -                                                   |
+| requestInterceptor          | interceptor to be executed on request    | (requestArg: RequestInitReturnedByInterceptor) => RequestInitReturnedByInterceptor | -                                                   |

--- a/examples/interceptor.ts
+++ b/examples/interceptor.ts
@@ -1,11 +1,12 @@
-import fetchAX, { RequestInit } from '../src';
+import fetchAX, { RequestInit, RequestInitReturnedByInterceptor } from '../src';
 
 const instance = fetchAX.create({
   responseInterceptor: (response: any) => {
     console.log('default options response interceptor');
     return response;
   },
-  requestInterceptor: (requestArg: RequestInit) => {
+  requestInterceptor: (requestArg: RequestInitReturnedByInterceptor) => {
+    requestArg.headers = {};
     console.log('default options reqeust interceptor');
     return requestArg;
   },
@@ -19,7 +20,8 @@ default options response interceptor
 requestInit response interceptor
  */
 const response = instance.get('/', {
-  requestInterceptor: (requestArg: RequestInit) => {
+  requestInterceptor: (requestArg: RequestInitReturnedByInterceptor) => {
+    requestArg.headers = { ...requestArg.headers };
     console.log('requestInit reqeust interceptor');
     return requestArg;
   },
@@ -29,4 +31,4 @@ const response = instance.get('/', {
   },
 });
 
-console.log(response)
+console.log(response);

--- a/src/index.ts
+++ b/src/index.ts
@@ -207,7 +207,15 @@ const isArrayBufferView = (data: any): data is ArrayBufferView => {
 };
 
 const isBodyInit = (data: any): data is BodyInit => {
+  const isJson = (data: any) => {
+    try {
+      return typeof JSON.parse(data) === 'object';
+    } catch (e) {
+      return false;
+    }
+  };
   return (
+    isJson(data) || // data === 'string' 을 통해서도 JSON인지를 확인할 수 있지만 명시적으로 따지기 위해서
     typeof data === 'string' ||
     data instanceof ReadableStream ||
     data instanceof Blob ||

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ export class FetchAxError<T> extends Error {
   }
 }
 
-type RequestInitReturnedByInterceptor = Omit<RequestInit, 'headers'> & {
+export type RequestInitReturnedByInterceptor = Omit<RequestInit, 'headers'> & {
   headers: Record<string, string>;
 };
 function getResponseContentType(response: Response): string {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -50,7 +50,9 @@ describe('next-fetch', () => {
       'https://jsonplaceholder.typicode.com/todos/1',
       //default
       {
-        headers: new Headers([['Content-Type', 'application/json']]),
+        headers: {
+          'content-type': 'application/json',
+        }, // options들은 headers 객체로 한 번 생성되기 때문에 소문자로 변경됨
         method: 'GET',
         throwError: true,
         responseType: 'json',
@@ -74,10 +76,10 @@ describe('next-fetch', () => {
     expect(fetchMocked).toHaveBeenCalledWith(
       'https://jsonplaceholder.typicode.com/todos/1',
       {
-        headers: new Headers({
-          'content-Type': 'application/json',
+        headers: {
+          'content-type': 'application/json',
           accept: 'application/json',
-        }),
+        },
         method: 'GET',
         throwError: true,
         responseType: 'json',
@@ -104,7 +106,7 @@ describe('next-fetch', () => {
     expect(fetchMocked).toHaveBeenCalledWith(
       'https://jsonplaceholder.typicode.com/todos/1',
       {
-        headers: new Headers([['Content-Type', 'application/json']]),
+        headers: { 'content-type': 'application/json' },
         method: 'GET',
         throwError: true,
         responseType: 'json',
@@ -164,7 +166,7 @@ describe('next-fetch', () => {
     expect(fetchMocked).toHaveBeenCalledWith(
       'https://jsonplaceholder.typicode.com/todos/1?id=1',
       {
-        headers: new Headers([['content-type', 'application/json']]),
+        headers: { 'content-type': 'application/json' },
         method: 'GET',
         throwError: true,
         responseType: 'json',


### PR DESCRIPTION
## **📌** 작업 내용

 <!-- 이미지 존재하는 경우 함께 표시 해주세요 -->

> 구현 내용 및 작업 했던 내역

closed #21 
closed #22 

- headers 객체 Record<string,string> 타입으로  지정 
- baseURL과 url을 new URL을 통해 합치는 것이 아닌 url이 상대 경로일 경우에만 문자열 합치는 형식으로 변경
- isBodyInit 함수에서 data type을 확인할 때 data가 JSON 타입이면 ` typeof data === 'string' ` 조건문에서 true더라구요 하지만 조금 더 명시적이면 좋을 것 같아 isJSON 함수를 구현 후 조건문에 추가해줬습니다

## 🔊 도움이 필요한 부분

-  `baseURL이 지정되어 있지 않은 상태에서 '/user/sr'와 같은 상대 경로를 넣으면 Invalid URL 에러가 발생합니다. (그래서 URL 쪽 일부를 수정했습니다.) baseURL 지정이 안 되어 있을 때 해당 origin으로 요청을 보내도록 개선하면 좋을 것 같습니다.` (https://github.com/Myongji-Graduate/myongji-graduate-next/pull/149)
- 저번 PR에서 baseURL이 없는 상태에서 /user/sr 상대 경로로 요청을 보내면 InvalidURL Error가 아닌 origin으로 요청을 보내야 할 것 같다고 하셨는데, /user/sr로 보내도 어차피 Fetch API에서 InvalidError를 발생시키더라구요 fetch-ax에서 InvalidError를 발생시키지 않게 수정을 해야 할 것 같다고 생각하신 이유가 있을까요??
- 저도 Fetch API에서 InvalidError 를 발생시키는 걸 뒤늦게 확인해서 일단 구현은 된 상태이며 baseURL, url 둘다 있는데 만약 url이 절대경로라면 baseURL이 무시되는 기능도 추가했습니다. 
```
TypeError: Failed to parse URL from sign-in
  [cause]: TypeError: Invalid URL
``` 
