### PR TITLE
change response type parsing logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ const instance = fetchAX.create({
 | baseURL                     | base url                                 | string \| URL                                         | -                                                   |
 | headers                     | fetch headers                            | HeadersInit                                           | new Headers([['Content-Type', 'application/json']]) |
 | throwError                  | whether to throw an error                | boolean                                               | true                                                |
-| responseType                | response type to parse                   | ResponseType                                          | json                                                |
+| responseType                | response type to parse                   | ResponseType                                          | -                                                   |
 | responseInterceptor         | interceptor to be executed on response   | (response: Response) => Response \| Promise<Response> | -                                                   |
 | responseRejectedInterceptor | interceptor to handle rejected responses | (error: any) => any                                   | -                                                   |
 | requestInterceptor          | interceptor to be executed on request    | (requestArg: RequestInit) => RequestInit              | -                                                   |

--- a/examples/responseType.ts
+++ b/examples/responseType.ts
@@ -1,11 +1,12 @@
-import fetchAX from "../src";
+import fetchAX from '../src';
 
 const instance = fetchAX.create();
 
-// This does not parse the response   
+// Automatically parses the response body as JSON if the 'Content-Type' header is 'application/json'.
+// Otherwise, returns the raw response body.
 const response = instance.get('/');
 
-// response data type is json 
+// response data type is json
 const responseWithJson = instance.get('/', {
   responseType: 'json',
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,16 @@ function getResponseContentType(response: Response): string {
   return contentType ? contentType.split(';')[0] : '';
 }
 
+const resolveResponseType = (
+  response: Response,
+  responseType?: ResponseType,
+) => {
+  if (responseType) return responseType;
+  return getResponseContentType(response) === 'application/json'
+    ? 'json'
+    : undefined;
+};
+
 export const httpErrorHandling = async (
   response: Response,
   requestArgs?: RequestInit,
@@ -97,43 +107,51 @@ export type FetchAXDefaultOptions = {
    */
   requestInterceptor?: (requestArg: RequestInit) => RequestInit;
 };
+const parseResponseData = async <T>(
+  response: Response,
+  type: ResponseType,
+): Promise<T> => {
+  switch (type) {
+    case 'arraybuffer':
+      return (await response.arrayBuffer()) as T;
+    case 'json':
+      return await response.json();
+    case 'text':
+      return (await response.text()) as T;
+    case 'formdata':
+      return (await response.formData()) as T;
+    case 'blob':
+      return (await response.blob()) as T;
+    default:
+      return response.body as T;
+  }
+};
+
+const buildFetchAXResponse = <T>(
+  response: Response,
+  data: T,
+): FetchAXResponse<T> => ({
+  data,
+  status: response.status,
+  statusText: response.statusText,
+  headers: response.headers,
+});
 
 const processReturnResponse = async <T = any>(
   response: Response,
   responseType?: ResponseType,
 ): Promise<FetchAXResponse<T>> => {
-  let data: T;
-  switch (responseType) {
-    case 'arraybuffer':
-      data = (await response.arrayBuffer()) as T;
-      break;
+  const resolvedResponseType = resolveResponseType(response, responseType);
+  if (!resolvedResponseType)
+    return buildFetchAXResponse<T>(response, response.body as T);
 
-    case 'json':
-      data = await response.json();
-      break;
-
-    case 'text':
-      data = (await response.text()) as T;
-      break;
-
-    case 'formdata':
-      data = (await response.formData()) as T;
-      break;
-
-    case 'blob':
-      data = (await response.blob()) as T;
-      break;
-
-    default:
-      data = response.body as T;
-      break;
+  try {
+    const data = await parseResponseData<T>(response, resolvedResponseType);
+    return buildFetchAXResponse(response, data);
+  } catch (error) {
+    console.error('Return of original object due to parse error:', error);
+    return buildFetchAXResponse<T>(response, response.body as T);
   }
-  return {
-    data,
-    status: response.status,
-    statusText: response.statusText,
-    headers: response.headers,
-  };
 };
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -137,8 +137,6 @@ const processReturnResponse = async <T = any>(
   responseType?: ResponseType,
 ): Promise<FetchAXResponse<T>> => {
   const resolvedResponseType = resolveResponseType(response, responseType);
-  if (!resolvedResponseType)
-    return buildFetchAXResponse<T>(response, response.body as T);
 
   try {
     const data = await parseResponseData<T>(response, resolvedResponseType);

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,12 +28,7 @@ export const httpErrorHandling = async (
   response: Response,
   requestArgs?: RequestInit,
 ) => {
-  const errorResponse = await processReturnResponse(
-    response,
-    getResponseContentType(response) === 'application/json'
-      ? 'json'
-      : undefined,
-  );
+  const errorResponse = await processReturnResponse(response);
   let error = new FetchAxError(response.status, errorResponse);
 
   if (requestArgs?.responseRejectedInterceptor) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -196,7 +196,7 @@ export interface RequestInit extends Omit<globalThis.RequestInit, 'body'> {
   requestInterceptor?: (requestArg: RequestInit) => RequestInit;
   /** Throw Error of fetch. If the throwError attribute is true, throw an error when the status is 300 or more */
   throwError?: boolean;
-  /** data's type */
+  /** Resposne data's type */
   responseType?: ResponseType;
 }
 const isArrayBufferView = (data: any): data is ArrayBufferView => {
@@ -522,8 +522,6 @@ export const presetOptions: FetchAXDefaultOptions = {
   headers: new Headers([['Content-Type', 'application/json']]),
 
   throwError: true,
-
-  responseType: 'json',
 
   // baseURL: ''
 };

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -16,6 +16,13 @@ describe('next-fetch', () => {
   beforeEach(() => {
     fetchMocked = jest.fn().mockResolvedValue({
       body: JSON.stringify(mockResponseData),
+      headers: {
+        get: (header: string) => {
+          if (header === 'Content-Type') {
+            return 'application/json';
+          }
+        },
+      },
       json: jest.fn().mockResolvedValue(mockResponseData),
     });
 
@@ -56,7 +63,6 @@ describe('next-fetch', () => {
         headers: new Headers([['Content-Type', 'application/json']]),
         method: 'GET',
         throwError: true,
-        responseType: 'json',
       },
     );
   });
@@ -83,7 +89,6 @@ describe('next-fetch', () => {
         }),
         method: 'GET',
         throwError: true,
-        responseType: 'json',
       },
     );
   });
@@ -110,7 +115,6 @@ describe('next-fetch', () => {
         headers: new Headers([['Content-Type', 'application/json']]),
         method: 'GET',
         throwError: true,
-        responseType: 'json',
       },
     );
   });
@@ -188,7 +192,6 @@ describe('next-fetch', () => {
         headers: new Headers([['content-type', 'application/json']]),
         method: 'GET',
         throwError: true,
-        responseType: 'json',
         params: {
           id: 1,
         },

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -6,14 +6,17 @@ describe('next-fetch', () => {
   let mockRequestInterceptor: jest.Mock;
   let mockResponseInterceptor: jest.Mock;
 
+  const mockResponseData = {
+    userId: 1,
+    id: 1,
+    title: 'delectus aut autem',
+    completed: false,
+  };
+
   beforeEach(() => {
     fetchMocked = jest.fn().mockResolvedValue({
-      json: jest.fn().mockResolvedValue({
-        userId: 1,
-        id: 1,
-        title: 'delectus aut autem',
-        completed: false,
-      }),
+      body: JSON.stringify(mockResponseData),
+      json: jest.fn().mockResolvedValue(mockResponseData),
     });
 
     // @ts-ignore
@@ -147,6 +150,24 @@ describe('next-fetch', () => {
     );
     //then
     expect(typeof data).toEqual(typeof JSON);
+  });
+
+  it('should returns the raw response body due to parsing error', async () => {
+    // given
+    const instance = fetchAX.create({ responseType: 'formdata' });
+    let error;
+    let response;
+    //when
+    try {
+      response = await instance.get(
+        'https://jsonplaceholder.typicode.com/todos/1',
+      );
+    } catch (e) {
+      error = e;
+    }
+    //then
+    expect(error).toEqual(undefined);
+    expect(typeof response?.data).toEqual('string');
   });
 
   it('should call request with params', async () => {


### PR DESCRIPTION
## **📌** 작업 내용

 <!-- 이미지 존재하는 경우 함께 표시 해주세요 -->

> 구현 내용 및 작업 했던 내역

#20 

- [x] reponse type parsing 로직의 변경

### 문제 
- responseType는 undefined를 허용하며, default로 json을 갖음 -> 하지만 응답 본문이 없는 경우에도 responseType가 json이므로 response.json()으로 파싱되는 문제가 존재

### 변경된 로직
1. responseType을 요청한 경우 -> responseType으로 parsing
2. responseType을 요청하지 않은 경우 -> 원본 데이터를 반환하되, content-type이 `application/json`인 경우에 한해서 json으로 parsing

원본데이터를 반환하는 경우

- **parsing에 실패하거나 `Content-Type`이 명시되지 않고 json형식이 아닌 경우, 원본 데이터를 그대로 반환**

## 🤔 고민 했던 부분

1. 우선순위
    - responseType이 있는 경우
    - content type = `application/json` 인 경우
   → responseType을 우선 순위로 함

2. 에러가 발생한 경우 parsing type
    - 파싱이 실패하면 Axios는 해당 데이터의 body를 그대로 반환하며, error를 throw하지 않음

3. parsing 될 값이 유추되는 content-type에 대해서 자동 parsing 기능 구현 -> 진행하지 않음
      - `axios`에서는 `application/json`이 아닌 타입에 대해서 원본 데이터를 그대로 반환하고 있음 -> 사용자가 `axios`와 동일하게 응답이 될 것이라는 기대가 존재
      - content-type이 `json`의 형태라고 하더라도 데이터가 어떤 맥락에서 사용되는지는 일치하지 않을 수 있으므로, `.json()`으로 무조건 파싱하는 것은 데이터의 컨텍스트 잃을 수 있다고 판단하여 원본 데이터의 반환을 통해 사용자가 유연하게 설계하도록 구현
       

위 에러 해결 과정도, 조금 더 구체적이게 졸부 노션의 문서자료-fetch-기타자료에 추가했습니다! https://soft-anorak-0ca.notion.site/responseType-json-parsing-514e09fbfde84edcb6f0be085b7af88a?pvs=4