### PR TITLE
fix: resolve exports error

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,12 +31,12 @@
   "exports": {
     ".": {
       "import": {
-        "types": "./lib/esm/types/index.d.ts",
-        "default": "./lib/esm/index.js"
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
       },
       "require": {
-        "types": "./lib/cjs/types/index.d.cts",
-        "default": "./lib/cjs/index.cjs"
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.cjs"
       }
     }
   },


### PR DESCRIPTION
## **📌** 작업 내용

 <!-- 이미지 존재하는 경우 함께 표시 해주세요 -->

> 구현 내용 및 작업 했던 내역

- [x]  exports 경로 오류 해결
- fetch-ax를 졸부에서 2.0.1 버전으로 업데이트 하였더니 모듈을 찾을 수 없다는 에러가 발생했습니다
- 왜 그런가 했더니 번들러로 업데이트 (https://github.com/Myongji-Graduate/fetch-ax/pull/15) 를 하면서 exports 경로를 수정하지 않아서 졸부에서 모듈을 찾지 못하고 있더라구요 ......... ㅠㅠㅠㅠㅠ
- 테스트 환경 ( nextjs 프로젝트 )을 만들어서 publish 할때마다 휴먼 테스트 진행이 필요할 것 같습니다 
