### PR TITLE
feat: automatic npm publish

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,50 @@
+name: Publish Package
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  version-check-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20.11.1'
+          registry-url: 'https://registry.npmjs.org/'
+
+      - name: Cache npm dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-cache-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-cache-
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check for version update
+        id: check_version
+        run: |
+          LATEST_VERSION=$(npm show $(jq -r '.name' package.json) version)
+
+          CURRENT_VERSION=$(jq -r '.version' package.json)
+
+          if [ "$CURRENT_VERSION" = "$LATEST_VERSION" ]; then
+            exit 0
+          # If를 열면 if를 닫는거 
+          fi
+
+          echo "::set-output name=version_updated::true"
+
+      - name: Publish package to npm
+        if: steps.check_version.outputs.version_updated == 'true'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -48,3 +48,11 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --access public
+
+      - name: Trigger webhook
+        if: steps.check_version.outputs.version_updated == 'true'
+        run: |
+          curl -X POST -H "Accept: application/vnd.github.v3+json" \
+          -H "Authorization: Bearer ${{ secrets.PAT }}" \
+          https://api.github.com/repos/Myongji-Graduate/myongji-graduate-next/dispatches \
+          -d '{"event_type": "fetch-ax-updated"}'


### PR DESCRIPTION
## **📌** 작업 내용

 <!-- 이미지 존재하는 경우 함께 표시 해주세요 -->

> 구현 내용 및 작업 했던 내역

closed #24 

- [x] npm publish 자동화 
- [x] npm publish 시 졸업을 부탁해 레포지토리에 fetch-ax-updated 이벤트 트리거 

## 🤔 고민 했던 부분

- package.json의 버전 변경하고 publish 안했던 경우도 종종 있었던 것 같고, 매번 버전 바뀔 때마다 직접 npm login 후 퍼블리시 하는 과정을 자동화 시키면 좋을 것 같아 진행했습니다.
- github actions 통해서 package.json 의 version이 변경되었을 시에 publish 합니다
- 이후에는 버전 업데이트 되었을 시, 졸부에도 업데이트 되도록 구현하겠습니다
- npm publish 시 repository_dispatch 날려서 졸부 workflow 실행하도록 구현했습니다 