### PR TITLE
fix: default content-type

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,8 @@ The available instance methods are listed below.
 
 ## ✔️ Parsing Response
 
-If you set a response type, you can parse the response with that type. The default type is 'json'.
+If you set a response type, you can parse the response with that type.
+If responseType is not set, the original data is returned. But parsed as `json` only if the content-type is `application/json`.
 
 ```tsx
 const instance = fetchAX.create();
@@ -274,3 +275,13 @@ const instance = fetchAX.create({
 | responseInterceptor         | interceptor to be executed on response   | (response: Response) => Response \| Promise<Response>                              | -       |
 | responseRejectedInterceptor | interceptor to handle rejected responses | (error: any) => any                                                                | -       |
 | requestInterceptor          | interceptor to be executed on request    | (requestArg: RequestInitReturnedByInterceptor) => RequestInitReturnedByInterceptor | -       |
+
+#### conditional auto default options
+
+##### responseType
+
+- By default, there is no default value for responseType. But it is `json` only if the content-type is `application/json`
+
+##### headers
+
+- By default, there is no default value for headers. But it's content-type is `application/json` only if the data is `json`

--- a/README.md
+++ b/README.md
@@ -265,12 +265,12 @@ const instance = fetchAX.create({
 
 ### default options
 
-| Property                    | Description                              | Type                                                                               | Default                                             |
-| --------------------------- | ---------------------------------------- | ---------------------------------------------------------------------------------- | --------------------------------------------------- |
-| baseURL                     | base url                                 | string \| URL                                                                      | -                                                   |
-| headers                     | fetch headers                            | HeadersInit                                                                        | new Headers([['Content-Type', 'application/json']]) |
-| throwError                  | whether to throw an error                | boolean                                                                            | true                                                |
-| responseType                | response type to parse                   | ResponseType                                                                       | -                                                   |
-| responseInterceptor         | interceptor to be executed on response   | (response: Response) => Response \| Promise<Response>                              | -                                                   |
-| responseRejectedInterceptor | interceptor to handle rejected responses | (error: any) => any                                                                | -                                                   |
-| requestInterceptor          | interceptor to be executed on request    | (requestArg: RequestInitReturnedByInterceptor) => RequestInitReturnedByInterceptor | -                                                   |
+| Property                    | Description                              | Type                                                                               | Default |
+| --------------------------- | ---------------------------------------- | ---------------------------------------------------------------------------------- | ------- |
+| baseURL                     | base url                                 | string \| URL                                                                      | -       |
+| headers                     | fetch headers                            | HeadersInit                                                                        | -       |
+| throwError                  | whether to throw an error                | boolean                                                                            | true    |
+| responseType                | response type to parse                   | ResponseType                                                                       | -       |
+| responseInterceptor         | interceptor to be executed on response   | (response: Response) => Response \| Promise<Response>                              | -       |
+| responseRejectedInterceptor | interceptor to handle rejected responses | (error: any) => any                                                                | -       |
+| requestInterceptor          | interceptor to be executed on request    | (requestArg: RequestInitReturnedByInterceptor) => RequestInitReturnedByInterceptor | -       |

--- a/README.md
+++ b/README.md
@@ -280,8 +280,8 @@ const instance = fetchAX.create({
 
 ##### responseType
 
-- By default, there is no default value for responseType. But it is `json` only if the content-type is `application/json`
+- By default, there is no default value for responseType. But it is set to `json` only if the content-type is `application/json`
 
 ##### headers
 
-- By default, there is no default value for headers. But it's content-type is `application/json` only if the data is `json`
+- By default, there is no default value for headers. But it's content-type is set to `application/json` only if the data is `json`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fetch-ax",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "A modern HTTP client that extends the Fetch API, providing Axios-like syntax and full compatibility with Next.js App Router.",
   "scripts": {
     "test": "jest",

--- a/src/index.ts
+++ b/src/index.ts
@@ -204,6 +204,15 @@ export interface RequestInit extends Omit<globalThis.RequestInit, 'body'> {
   /** Resposne data's type */
   responseType?: ResponseType;
 }
+
+const isJson = (data: any) => {
+  try {
+    return typeof JSON.parse(data) === 'object';
+  } catch (e) {
+    return false;
+  }
+};
+
 const isArrayBufferView = (data: any): data is ArrayBufferView => {
   return (
     data &&
@@ -218,17 +227,10 @@ const isArrayBufferView = (data: any): data is ArrayBufferView => {
 };
 
 const isBodyInit = (data: any): data is BodyInit => {
-  const isJson = (data: any) => {
-    try {
-      return typeof JSON.parse(data) === 'object';
-    } catch (e) {
-      return false;
-    }
-  };
   return (
     isJson(data) || // data === 'string' 을 통해서도 JSON인지를 확인할 수 있지만 명시적으로 따지기 위해서
     typeof data === 'string' ||
-    data instanceof ReadableStream ||
+    (typeof ReadableStream !== 'undefined' && data instanceof ReadableStream) ||
     data instanceof Blob ||
     data instanceof ArrayBuffer ||
     data instanceof FormData ||
@@ -288,6 +290,7 @@ const applyDefaultOptionsArgs = (
   );
 
   const requestHeaders: Record<string, string> = {};
+
   if (defaultOptions?.headers) {
     new Headers(defaultOptions.headers).forEach((value, key) => {
       requestHeaders[key] = value;
@@ -297,6 +300,10 @@ const applyDefaultOptionsArgs = (
     new Headers(requestInit.headers).forEach((value, key) => {
       requestHeaders[key] = value;
     });
+  }
+
+  if (requestInit?.data) {
+    appendJsonContentType(requestInit.data, requestHeaders);
   }
 
   let requestArgs = {
@@ -332,6 +339,16 @@ const applyDefaultOptionsArgs = (
 
 function isHttpError(response: Response) {
   return response.status >= 300;
+}
+
+function appendJsonContentType(
+  data: Record<string, any> | BodyInit,
+  requestHeaders: Record<string, string>,
+) {
+  if (isJson(JSON.stringify(data)) && !requestHeaders['content-type']) {
+    requestHeaders['content-type'] = 'application/json';
+  }
+  return requestHeaders;
 }
 
 function ensureBodyInit(data: BodyInit | Record<string, any>): BodyInit {

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,7 +109,7 @@ export type FetchAXDefaultOptions = {
 };
 const parseResponseData = async <T>(
   response: Response,
-  type: ResponseType,
+  type?: ResponseType,
 ): Promise<T> => {
   switch (type) {
     case 'arraybuffer':
@@ -565,8 +565,6 @@ const fetchAX = {
 };
 export default fetchAX;
 export const presetOptions: FetchAXDefaultOptions = {
-  headers: { 'Content-Type': 'application/json' },
-
   throwError: true,
 
   // baseURL: ''

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -198,6 +198,29 @@ describe('next-fetch', () => {
       },
     );
   });
+
+  it('should append content-type application/json if data is a JSON object', async () => {
+    // given
+    const instance = fetchAX.create();
+
+    // when
+    await instance.post('https://jsonplaceholder.typicode.com/todos/1', {
+      test: 'test',
+    });
+
+    // then
+    expect(fetchMocked).toHaveBeenCalledWith(
+      'https://jsonplaceholder.typicode.com/todos/1',
+
+      {
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ test: 'test' }),
+        data: { test: 'test' },
+        method: 'POST',
+        throwError: true,
+      },
+    );
+  });
 });
 
 describe('next-fetch-error', () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -60,9 +60,7 @@ describe('next-fetch', () => {
       'https://jsonplaceholder.typicode.com/todos/1',
       //default
       {
-        headers: {
-          'content-type': 'application/json',
-        }, // options들은 headers 객체로 한 번 생성되기 때문에 소문자로 변경됨
+        headers: {}, // options들은 headers 객체로 한 번 생성되기 때문에 소문자로 변경됨
         method: 'GET',
         throwError: true,
       },
@@ -191,7 +189,7 @@ describe('next-fetch', () => {
     expect(fetchMocked).toHaveBeenCalledWith(
       'https://jsonplaceholder.typicode.com/todos/1?id=1',
       {
-        headers: { 'content-type': 'application/json' },
+        headers: {},
         method: 'GET',
         throwError: true,
         params: {


### PR DESCRIPTION
## **📌** 작업 내용

 <!-- 이미지 존재하는 경우 함께 표시 해주세요 -->

> 구현 내용 및 작업 했던 내역

- [x] fetch-ax의 header의 default value 제거
- [x] data가 JSON type인 경우, 자동으로 `application/json`을 content-type으로 설정하는 로직 추가
- [x] README에 조건부로 발생하는 default value 반영

### 문제
- fetch는 content-type을 지정하지 않고 formdata를 body로 설정하는 경우, 브라우저가 자동으로 content-type을 설정해주는 기능을 제공합니다. fetch-ax의 경우 content-type의 기본값이 `application/json`으로 설정되어 있어 오류가 발생합니다.

## 🤔 고민 했던 부분


### fetch-ax가 content-type의 기본값을 `application/json`으로 설정한 목적
- data가 json형식이 가장 많이 전송 될 것이라고 예상했기 때문
-> fetch-ax가 content-type의 기본값을 `application/json`으로 설정한 목적을 충족시키기 위해, data가 JSON type인 경우에 자동으로 `application/json`을 content-type으로 설정하는 로직을 추가해 이를 대응

### 변경된 로직
- content-type의 기본값 제거
- data가 JSON type인 경우, 자동으로 `application/json`을 content-type으로 설정


